### PR TITLE
Fix: Append .exe to chromedriver path on Windows

### DIFF
--- a/webdriver_setup.py
+++ b/webdriver_setup.py
@@ -35,6 +35,8 @@ def get_driver_info():
         raise RuntimeError(f"Unsupported platform: {platform.system()} {platform.machine()}")
 
     expected_driver_path = Path.cwd() / "chromedriver"
+    if platform.system() == 'Windows':
+        expected_driver_path = expected_driver_path.with_suffix('.exe')
 
     url = "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json"
     try:


### PR DESCRIPTION
The script was failing to locate the chromedriver executable on Windows because it was searching for 'chromedriver' instead of 'chromedriver.exe'.

This commit modifies `webdriver_setup.py` to check the operating system. If the OS is Windows, it appends the '.exe' suffix to the chromedriver filename, ensuring the correct file is found.