### PR TITLE
feat: Add crawl session logging

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -31,6 +31,9 @@ class Crawler:
         self.url_queue = deque([start_url])
         self.visited_urls = {start_url}
 
+        self.pages_crawled = 0
+        self.datasets_found = 0
+
         self.parser = Parser(base_url=start_url)
         self.scorer = Scorer()
         self.domain = urlparse(start_url).netloc
@@ -73,9 +76,8 @@ class Crawler:
         """
         Executes the crawling process.
         """
-        pages_crawled = 0
         try:
-            while self.url_queue and pages_crawled < self.max_pages:
+            while self.url_queue and self.pages_crawled < self.max_pages:
                 current_url = self.url_queue.popleft()
                 print(f"Crawling: {current_url}")
 
@@ -93,6 +95,7 @@ class Crawler:
                 datasets, new_links = self.parser.parse(html_content, current_url)
 
                 # Process found datasets
+                self.datasets_found += len(datasets)
                 for dataset in datasets:
                     freshness_score = self.scorer.calculate_freshness_score(
                         dataset['date_clues'], dataset['title_clues']
@@ -114,7 +117,7 @@ class Crawler:
                         self.visited_urls.add(link)
                         self.url_queue.append(link)
 
-                pages_crawled += 1
+                self.pages_crawled += 1
                 print(f"  Found {len(new_links)} new links. Queue size: {len(self.url_queue)}")
 
                 # Politeness delay

--- a/db_manager.py
+++ b/db_manager.py
@@ -34,6 +34,55 @@ class DBManager:
         CREATE UNIQUE INDEX IF NOT EXISTS idx_dataset_location
         ON datasets (source_url, download_link);
         ''')
+        self.cursor.execute('''
+        CREATE TABLE IF NOT EXISTS crawl_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            start_url TEXT NOT NULL,
+            start_time DATETIME NOT NULL,
+            end_time DATETIME,
+            pages_crawled INTEGER,
+            datasets_found INTEGER,
+            status TEXT NOT NULL
+        );
+        ''')
+        self.conn.commit()
+
+    def start_crawl_log(self, start_url):
+        """
+        Logs the start of a new crawl session.
+
+        Args:
+            start_url (str): The starting URL for the crawl.
+
+        Returns:
+            int: The ID of the new crawl log entry.
+        """
+        sql = '''
+        INSERT INTO crawl_logs (start_url, start_time, status)
+        VALUES (?, ?, ?);
+        '''
+        start_time = datetime.datetime.now()
+        self.cursor.execute(sql, (start_url, start_time, 'in_progress'))
+        self.conn.commit()
+        return self.cursor.lastrowid
+
+    def end_crawl_log(self, log_id, pages_crawled, datasets_found, status):
+        """
+        Logs the completion of a crawl session.
+
+        Args:
+            log_id (int): The ID of the crawl log entry to update.
+            pages_crawled (int): The total number of pages crawled.
+            datasets_found (int): The total number of datasets found.
+            status (str): The final status of the crawl ('completed' or 'interrupted').
+        """
+        sql = '''
+        UPDATE crawl_logs
+        SET end_time = ?, pages_crawled = ?, datasets_found = ?, status = ?
+        WHERE id = ?;
+        '''
+        end_time = datetime.datetime.now()
+        self.cursor.execute(sql, (end_time, pages_crawled, datasets_found, status, log_id))
         self.conn.commit()
 
     def add_or_update_dataset(self, dataset_data):

--- a/main.py
+++ b/main.py
@@ -48,12 +48,25 @@ def main():
     )
 
     # 3. Start the crawl
+    log_id = None
+    status = "completed"
     try:
+        log_id = db_manager.start_crawl_log(args.url)
         crawler.crawl()
     except KeyboardInterrupt:
         print("\nCrawling interrupted by user.")
+        status = "interrupted"
     finally:
         # 4. Clean up
+        if log_id is not None:
+            print("Logging crawl session...")
+            db_manager.end_crawl_log(
+                log_id=log_id,
+                pages_crawled=crawler.pages_crawled,
+                datasets_found=crawler.datasets_found,
+                status=status
+            )
+
         print("Closing database connection.")
         db_manager.close()
         print("Done.")


### PR DESCRIPTION
This commit introduces a new feature to log high-level statistics for each crawl session.

A new table, `crawl_logs`, has been added to the database to store metrics such as the start URL, start and end times, the number of pages crawled, and the number of datasets found.

The `Crawler` class has been updated to track the number of pages crawled and datasets found. The `DBManager` now includes methods to start and end a crawl log entry. The `main` function has been modified to orchestrate this process, ensuring that crawl statistics are recorded even if the process is interrupted.